### PR TITLE
Allow X-Frame-Option to not be sent

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -22,9 +22,10 @@ module.exports = function(done, app, options) {
     if (options.csp !== false) {
         app.use(helmet.contentSecurityPolicy(middlewareOptions('csp', options)));
     }
-
+    if(options.frameguard !== false){
+        app.use(helmet.frameguard.apply(this, middlewareOptions('frameguard', options)));
+    }
     app.use(helmet.xssFilter());
-    app.use(helmet.frameguard.apply(this, middlewareOptions('frameguard', options)));
     app.use(helmet.hsts(middlewareOptions('hsts', options)));
     // app.use(helmet.crossdomain(middlewareOptions('crossdomain', options)));
     app.use(helmet.noSniff());


### PR DESCRIPTION
* X-Frame-Option only allows one value and therefor the website cannot be embedded in multiple different sites, unless we can turn this off
* X-Frame-Option also is not supported on chrome