### PR TITLE
Adds Coverall testing to Elephas

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,74 @@
+module.exports = function(grunt){
+    grunt.initConfig({
+//        mochaTest: {
+//            test: {
+//                options: {
+//                    require: './tests/blanket',
+//                    reporter: 'spec',
+//                    quiet: false, // Optionally suppress output to standard out (defaults to false)
+//                },
+//                src: ['**/__test__/*.js']
+//            },
+//            coverage:{
+//                options : {
+//                    require: './tests/bable-setup.js',
+//                    reporter: 'html-cov',
+//                    quiet: false,
+//                    captureFile: 'coverage.html'
+//                },
+//                src: ['**/__test__/*.js']
+//            }
+//        }
+        mocha_istanbul: {
+            target : {
+                options : {
+                    dryRun: true,
+                    ui: true,
+                    scriptPath: require.resolve('babel-istanbul'),
+                    istanbulOptions: '--use-babel-runtime',
+                    require: './test/test-setup.js'
+                    //mochaOptions: '--require ./tests/bable-setup.js' 
+                }
+            },
+            coverage: {
+                src: ['**/__test__/*.js'], 
+                options : {
+                    dryRun: false,
+                    coverageFolder: 'coverage',
+                    root: './lib',
+                    excludes: ['**/__test__/*.js'],
+                    print: 'detail',
+//                    scriptPath: require.resolve('babel-istanbul'),
+                    istanbulOptions: ['--use-babel-runtime'],
+                    //mochaOptions: ['require ./tests/bable-setup.js'],
+                    require: './test/test-setup.js',
+                    recursive: true,
+                    istanbulOptions: ['--include-all-sources'],
+//                    reportFormats:  ['lcov', 'html'] 
+                }
+            }
+        },
+        coveralls: {
+        // Options relevant to all targets
+            options: {
+              // When true, grunt-coveralls will only print a warning rather than
+              // an error, to prevent CI builds from failing unnecessarily (e.g. if
+              // coveralls.io is down). Optional, defaults to false.
+              force: true
+            },
+
+            post_lcov: {
+            // LCOV coverage file (can be string, glob or array)
+                src: 'coverage/lcov.info',
+                options: {
+                    // Any options for just this target
+                }
+            },
+        },
+    });
+    grunt.loadNpmTasks('grunt-mocha-istanbul');
+    grunt.loadNpmTasks('grunt-coveralls');
+    grunt.registerTask('test', ['mocha_istanbul:coverage', 'coveralls:post_lcov']);
+};
+
+

--- a/lib/__test__/wsRouter-test.js
+++ b/lib/__test__/wsRouter-test.js
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import sinon from 'sinon';
-import wsRouter from '../lib/wsRouter';
+import wsRouter from '../wsRouter';
 
 const _testRoutes = [{
     MY_TEST_ACTION: sinon.spy()

--- a/package.json
+++ b/package.json
@@ -4,13 +4,14 @@
   "description": "Some added sugar on top of express to give our our some sensible defaults and a little structure.",
   "main": "elephas.js",
   "scripts": {
-    "test": "mocha --compilers js:babel-core/register --recursive",
+    "test": "grunt test",
     "test:watch": "npm run test -- --watch"
   },
   "author": "atridge.dcosta@bigdatr.com",
   "license": "BSD-3-Clause",
   "dependencies": {
     "async": "^1.5.0",
+    "babel": "^5.8.34",
     "body-parser": "^1.12.4",
     "chalk": "^1.1.1",
     "compression": "^1.4.4",
@@ -34,10 +35,13 @@
     "express": "^4.13.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.1.18",
-    "babel-core": "^6.1.21",
-    "babel-preset-es2015": "^6.1.18",
+    "babel": "^5.8.34",
+    "babel-istanbul": "^0.5.8",
     "chai": "^3.4.1",
+    "grunt": "^0.4.5",
+    "grunt-coveralls": "^1.0.0",
+    "grunt-mocha-istanbul": "^3.0.1",
+    "istanbul": "^0.4.0",
     "mocha": "^2.3.4",
     "sinon": "^1.17.2"
   },
@@ -51,10 +55,5 @@
   "bugs": {
     "url": "https://github.com/bigdatr/elephas/issues"
   },
-  "homepage": "https://github.com/bigdatr/elephas",
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  }
+  "homepage": "https://github.com/bigdatr/elephas"
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-istanbul": "^0.5.8",
     "chai": "^3.4.1",
     "grunt": "^0.4.5",
+    "grunt-cli": "^0.1.13",
     "grunt-coveralls": "^1.0.0",
     "grunt-mocha-istanbul": "^3.0.1",
     "istanbul": "^0.4.0",

--- a/test/test-setup.js
+++ b/test/test-setup.js
@@ -1,0 +1,5 @@
+var winston = require('winston');
+require("babel/register");
+
+// Disable logging while testing.
+//var logger = require('../lib/logger');


### PR DESCRIPTION
Can remove the `var winston = require('winston');` line from `test/test-setup.js` although you may want to use it to deregister the console logger so that tests run without a tonne of debug logs.

add `COVERALLS_REPO_TOKEN` and `COVERALLS_SERVICE_NAME` into build system

* https://coveralls.io/github/thepont/elephas