### PR TITLE
move the eventEmitter.call inside the class function

### DIFF
--- a/lib/Service.js
+++ b/lib/Service.js
@@ -1,11 +1,12 @@
-'user strict';
+'use strict';
 
 var util = require("util"),
     events = require("events");
 
-function Service() {}
+function Service() {
+    events.EventEmitter.call(this);    
+}
 
-events.EventEmitter.call(this);
 
 util.inherits(Service, events.EventEmitter);
 


### PR DESCRIPTION
newer versions of node cause something to be undefined when it's called outside.
Which then causes errors down the line

https://github.com/Simperium/node-simperium/issues/10