### PR TITLE
Fix the logging order so that we can choose what gets logged

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 logs
 *.log
 
+tag*
 # Runtime data
 pids
 *.pid

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -77,6 +77,7 @@ function elephas(options) {
 
     logger.transports.console.level = options.logger.level || 'debug';
 
+
     if (options.__dirname) {
         options.routes_root_path = options.routes_root_path || options.__dirname;
         options.services_root_path = options.services_root_path || options.__dirname;
@@ -161,22 +162,17 @@ function elephas(options) {
 
                 _statsd.timing('elephas.startup_time', _duration);
 
-                console.log('\n');
-                console.log('------------');
-                console.log('ELEPHAS');
-                console.log('------------');
 
-                console.log('NODE_ENV: ' + process.env.NODE_ENV, '\n');
+                logger.debug('NODE_ENV: ' + process.env.NODE_ENV, '\n');
 
                 timerResults.forEach(function(t, i) {
                     var _start = i === 0 ? _startTime : timerResults[i-1].completed;
                     var _duration = t.completed - _start;
-                    console.log(_duration + 'ms', '\t', t.task);
+                    logger.debug(_duration + 'ms', Array(8 - _duration.toString().length).join(' '), t.task);
                 });
 
-                console.log('================================');
-                console.log(_duration + 'ms', '\t', 'TOTAL STARTUP DURATION')
-                console.log('\n');
+                logger.debug('=================================');
+                logger.debug(_duration + 'ms', Array(8 - _duration.toString().length).join(' '), 'TOTAL STARTUP DURATION')
             });
         }
     };

--- a/lib/framework.js
+++ b/lib/framework.js
@@ -163,7 +163,7 @@ function elephas(options) {
                 _statsd.timing('elephas.startup_time', _duration);
 
 
-                logger.debug('NODE_ENV: ' + process.env.NODE_ENV, '\n');
+                logger.debug('NODE_ENV: ' + process.env.NODE_ENV);
 
                 timerResults.forEach(function(t, i) {
                     var _start = i === 0 ? _startTime : timerResults[i-1].completed;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,26 +1,35 @@
 var winston = require('winston');
 
+var levels = {
+    // NPM style levels
+    error: 0,
+    warn: 1,
+    info: 2,
+    verbose: 3,
+    debug: 4,
+    silly: 5,
+
+    // Custom
+    query: 1,
+    failed: 1,
+    success: 1,
+    warning: 1
+}
+
+var colors = {
+    info: 'grey',
+    debug: 'grey',
+    warn: 'yellow',
+    warning: 'yellow',
+    error: 'red',
+    success: 'green',
+    failed: 'red',
+    query: 'magenta'
+}
+
 var logger = new (winston.Logger)({
-    levels: {
-        error: 0,
-        query: 1,
-        failed: 1,
-        success: 1,
-        warn: 1,
-        warning: 1,
-        info: 2,
-        debug: 3
-    },
-    colors: {
-        info: 'grey',
-        debug: 'grey',
-        warn: 'yellow',
-        warning: 'yellow',
-        error: 'red',
-        success: 'green',
-        failed: 'red',
-        query: 'magenta'
-    }
+    levels: levels,
+    colors: colors
 });
 
 logger.add(winston.transports.Console, {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,7 +3,7 @@ var winston = require('winston');
 var logger = new (winston.Logger)({
     levels: {
         error: 0,
-        query: 1
+        query: 1,
         failed: 1,
         success: 1,
         warn: 1,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,18 +1,15 @@
-'use strict';
 var winston = require('winston');
-
-// winston.transports.Kafka = require('winston-kafka-transport');
 
 var logger = new (winston.Logger)({
     levels: {
+        error: 0,
+        query: 1
+        failed: 1,
+        success: 1,
+        warn: 1,
+        warning: 1,
         info: 2,
-        debug: 1,
-        warn: 3,
-        warning: 3,
-        error: 4,
-        success: 3,
-        failed: 3,
-        query: 2
+        debug: 3
     },
     colors: {
         info: 'grey',
@@ -29,13 +26,7 @@ var logger = new (winston.Logger)({
 logger.add(winston.transports.Console, {
     timestamp: true, 
     colorize: true,
-    // level: 'warning',
-    // json: true,
-    prettyPrint: true,
-    // formatter: function(options) {
-    //     return '(' + process.pid + ') ' + new Date().toISOString() +' '+ options.level.toUpperCase() +' '+ (undefined !== options.message ? options.message : '') +
-    //       (options.meta && Object.keys(options.meta).length ? '\n\t'+ JSON.stringify(options.meta) : '' );
-    // }
+    prettyPrint: true
 });
 
 module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "recursive-readdir": "^1.3.0",
     "rx": "^4.0.7",
     "sockjs": "^0.3.15",
-    "winston": "^1.1.1"
+    "winston": "^2.1.1"
   },
   "peerDependencies": {
     "lodash": ">=3.10.1",


### PR DESCRIPTION
the error codes are actually in reverse. The lower the number the more priority it gets. 
So when you set the log level to 3 you get messages with a number 3 and below.